### PR TITLE
Fixed issue with capital file types

### DIFF
--- a/src/controllers/channel/image-channels.ts
+++ b/src/controllers/channel/image-channels.ts
@@ -90,7 +90,7 @@ function compileIds(array: string[]): string {
 
 function endsInWhitelist(attachment: string): boolean {
     for (const type in whitelistTypes) {
-        if (attachment.endsWith(whitelistTypes[type])) {
+        if (attachment.toLowerCase.endsWith(whitelistTypes[type])) {
             return true;
         }
     }


### PR DESCRIPTION
Fixed an issue where the bot would delete images if they had upper case file types (.PNG) by converting them to lower case before checking